### PR TITLE
Update name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "id": "android-messages",
-  "name": "android-messages",
-  "version": "1.1.0",
+  "name": "Android Messages",
+  "version": "1.1.1",
   "description": "Android Messages",
   "main": "index.js",
   "author": "Daniel Weinberger",


### PR DESCRIPTION
This patch is updating the name from `android-messages` to `Android Messages` and bumps the version to 1.1.1